### PR TITLE
add flattenThread

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ threadlib.getPostThread (ssb, mid, opts, cb)
 // `opts` used in fetchThreadData
 threadlib.getParentPostThread (ssb, mid, opts, cb)
 
+// get a flattened msg-list of the thread, ready for rendering
+threadlib.flattenThread (thread)
+
 // get top-level thread structure (no replies of replies)
 // `opts` used in fetchThreadData
 threadlib.getPostSummary (ssb, mid, opts, cb)

--- a/index.js
+++ b/index.js
@@ -130,7 +130,7 @@ exports.flattenThread = function (thread) {
       if (addedIds.has(msg.key))
         return // skip duplicates
       // insert if a mention to its parent
-      if (msg.value.content.type == 'post' && relationsTo(msg, parent).indexOf('mentions') >= 0)
+      if (msg.value.content.type == 'post' && isaMentionTo(msg, parent))
         insertMention(msg, parent.key)
     })
   }
@@ -378,21 +378,11 @@ exports.getLastThreadPost = function (thread) {
   return msg
 }
 
-// TODO move these to mlib
-
 function isaReplyTo (a, b) {
-  var ac = a.value.content
-  return (ac.root && mlib.link(ac.root).link == b.key || ac.branch && mlib.link(ac.branch).link == b.key)
+  var rels = mlib.relationsTo(a, b)
+  return rels.indexOf('root') >= 0 || rels.indexOf('branch') >= 0
 }
 
-function relationsTo (a, b) {
-  var rels = []
-  var ac = a.value.content
-  for (var k in ac) {
-    mlib.links(ac[k]).forEach(l => {
-      if (l.link === b.key)
-        rels.push(k)
-    })
-  }
-  return rels
+function isaMentionTo (a, b) {
+  return mlib.relationsTo(a, b).indexOf('mentions') >= 0
 }

--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ exports.flattenThread = function (thread) {
   // build the thread into a flat, and correctly ordered, list
   // this means 
   // 1. putting all renderable messages (root, replies, and mentions) in a flat msgs list (so no recursion is required to render)
-  // 2. ordering thread.related such that replies are always after their immediate parent
+  // 2. ordering the list such that replies are always after their immediate parent
   // 3. weaving in mentions in a second pass (if a mention is also a reply, we want that to take priority)
   // 4. detecting missing parents and weaving in "hey this is missing" objects
   var availableIds = new Set([thread.key].concat(thread.related.map(function (m) { return m.key })))

--- a/index.js
+++ b/index.js
@@ -65,10 +65,11 @@ exports.flattenThread = function (thread) {
   // 2. ordering the list such that replies are always after their immediate parent
   // 3. weaving in mentions in a second pass (if a mention is also a reply, we want that to take priority)
   // 4. detecting missing parents and weaving in "hey this is missing" objects
-  var availableIds = new Set([thread.key].concat(thread.related.map(function (m) { return m.key })))
+  var related = (thread.related||[])
+  var availableIds = new Set([thread.key].concat(related.map(function (m) { return m.key })))
   var addedIds = new Set([thread.key])
   var msgs = [thread]
-  ;(thread.related||[]).forEach(flattenAndReorderReplies)
+  related.forEach(flattenAndReorderReplies)
   var msgsDup = msgs.slice() // duplicate so the weave iterations dont get disrupted by splices
   msgsDup.forEach(weaveMentions)
   msgsDup.forEach(weaveMissingParents)

--- a/package.json
+++ b/package.json
@@ -25,12 +25,11 @@
   "dependencies": {
     "multicb": "^1.2.0",
     "pull-stream": "^2.28.4",
-    "ssb-msgs": "^5.1.0"
+    "ssb-msgs": "^5.2.0"
   },
   "devDependencies": {
     "level-sublevel": "^6.5.2",
     "level-test": "^2.0.1",
-    "multicb": "^1.2.0",
     "secure-scuttlebutt": "^15.0.0",
     "ssb-keys": "^4.0.6",
     "tape": "~4.0.0"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Library for Patchwork's thread data-structures",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "set -e; for t in test/*.js; do node $t; done"
   },
   "repository": {
     "type": "git",
@@ -26,5 +26,13 @@
     "multicb": "^1.2.0",
     "pull-stream": "^2.28.4",
     "ssb-msgs": "^5.1.0"
+  },
+  "devDependencies": {
+    "level-sublevel": "^6.5.2",
+    "level-test": "^2.0.1",
+    "multicb": "^1.2.0",
+    "secure-scuttlebutt": "^15.0.0",
+    "ssb-keys": "^4.0.6",
+    "tape": "~4.0.0"
   }
 }

--- a/test/flatten.js
+++ b/test/flatten.js
@@ -7,6 +7,32 @@ var defaults  = require('secure-scuttlebutt/defaults')
 var ssbKeys   = require('ssb-keys')
 var threadlib = require('../')
 
+tape('flattenThread correctly works without replies', function (t) {
+
+  var db = sublevel(level('test-patchwork-threads-flatten-noreplies', {
+    valueEncoding: defaults.codec
+  }))
+  var ssb = SSB(db, defaults)
+
+  var alice = ssb.createFeed(ssbKeys.generate())
+
+  // load test thread into ssb
+  alice.add({ type: 'post', text: 'a' }, function (err, msgA) {
+    if (err) throw err
+
+    // fetch and flatten the thread
+    threadlib.getPostThread(ssb, msgA.key, {}, function (err, thread) {
+      if (err) throw err
+
+      var msgs = threadlib.flattenThread(thread)
+      t.equal(msgs.length, 1)
+      // ensure msgs were interpretted correctly
+      t.equal(msgs[0].key, msgA.key)
+      t.end()
+    })
+  })
+})
+
 tape('flattenThread correctly orders despite bad timestamps', function (t) {
 
   var db = sublevel(level('test-patchwork-threads-flatten-order', {

--- a/test/flatten.js
+++ b/test/flatten.js
@@ -109,6 +109,56 @@ tape('flattenThread correctly weaves mentions into the thread', function (t) {
   })
 })
 
+tape('flattenThread correctly detects missing parents', function (t) {
+
+  var db = sublevel(level('test-patchwork-threads-flatten-missing-parents', {
+    valueEncoding: defaults.codec
+  }))
+  var ssb = SSB(db, defaults)
+
+  var alice = ssb.createFeed(ssbKeys.generate())
+  var bob = ssb.createFeed(ssbKeys.generate())
+  var carla = ssb.createFeed(ssbKeys.generate())
+
+  // load test thread into ssb
+  alice.add({ type: 'post', text: 'a' }, function (err, msgA) {
+    if (err) throw err
+
+    // first reply
+    bob.add({ type: 'post', text: 'b', root: msgA.key, branch: msgA.key }, function (err, msgB) {
+      if (err) throw err
+
+      // second reply
+      carla.add({ type: 'post', text: 'c', root: msgA.key, branch: msgB.key }, function (err, msgC) {
+        if (err) throw err
+
+        // fetch thread
+        threadlib.getPostThread(ssb, msgA.key, {}, function (err, thread) {
+          if (err) throw err
+
+          // delete the first reply
+          // 0 & 1 are msgB (0 for root and 1 for branch) delete them both
+          thread.related.splice(0, 2)
+          console.log(thread.related[0].key)
+
+          // now flatten
+          var msgs = threadlib.flattenThread(thread)
+          console.log(msgs[0].key)
+          t.equal(msgs.length, 3)
+          // ensure msgs were interpretted correctly
+          t.equal(msgs[0].key, msgA.key)
+          t.equal(!!msgs[0].isNotFound, false)
+          t.equal(msgs[1].key, msgB.key) 
+          t.equal(!!msgs[1].isNotFound, true) // our missing post
+          t.equal(msgs[2].key, msgC.key)
+          t.equal(!!msgs[2].isNotFound, false)
+          t.end()
+        })
+      })
+    })
+  })
+})
+
 function customTimeCreateMsg (keys, timestamp, content) {
   return ssbKeys.signObj(keys, {
     previous: null,

--- a/test/flatten.js
+++ b/test/flatten.js
@@ -165,11 +165,9 @@ tape('flattenThread correctly detects missing parents', function (t) {
           // delete the first reply
           // 0 & 1 are msgB (0 for root and 1 for branch) delete them both
           thread.related.splice(0, 2)
-          console.log(thread.related[0].key)
 
           // now flatten
           var msgs = threadlib.flattenThread(thread)
-          console.log(msgs[0].key)
           t.equal(msgs.length, 3)
           // ensure msgs were interpretted correctly
           t.equal(msgs[0].key, msgA.key)

--- a/test/flatten.js
+++ b/test/flatten.js
@@ -1,0 +1,71 @@
+var tape      = require('tape')
+var multicb   = require('multicb')
+var level     = require('level-test')()
+var sublevel  = require('level-sublevel/bytewise')
+var SSB       = require('secure-scuttlebutt')
+var defaults  = require('secure-scuttlebutt/defaults')
+var ssbKeys   = require('ssb-keys')
+var threadlib = require('../')
+
+function customTimeCreateMsg (keys, timestamp, content) {
+  return ssbKeys.signObj(keys, {
+    previous: null,
+    author: keys.id,
+    sequence: 1,
+    timestamp: timestamp,
+    hash: 'sha256',
+    content: content,
+  })
+}
+
+tape('flattenThread correctly orders despite bad timestamps', function (t) {
+
+  var db = sublevel(level('test-patchwork-threads-flatten-order', {
+    valueEncoding: defaults.codec
+  }))
+  var ssb = SSB(db, defaults)
+
+  var alice = ssbKeys.generate()
+  var bob = ssbKeys.generate()
+  var carla = ssbKeys.generate()
+  var dan = ssbKeys.generate()
+
+  // load test thread into ssb
+  ssb.add(customTimeCreateMsg(alice, Date.now(), { type: 'post', text: 'a' }), function (err, msgA) {
+    if (err) throw err
+
+    // first reply
+    ssb.add(customTimeCreateMsg(bob, Date.now(), { type: 'post', text: 'b', root: msgA.key, branch: msgA.key }), function (err, msgB) {
+      if (err) throw err
+
+      // second reply, with TS too early by an hour
+      ssb.add(customTimeCreateMsg(carla, Date.now() - 1000*60*60, { type: 'post', text: 'c', root: msgA.key, branch: msgB.key }), function (err, msgC) {
+        if (err) throw err
+
+        // third reply, with TS too early by two hours
+        ssb.add(customTimeCreateMsg(dan, Date.now() - 1000*60*60*2, { type: 'post', text: 'd', root: msgA.key, branch: msgC.key }), function (err, msgD) {
+          if (err) throw err
+
+          // fetch and flatten the thread
+          threadlib.getPostThread(ssb, msgA.key, {}, function (err, thread) {
+            if (err) throw err
+
+            // check that messages are in the bad order we expect
+            t.equal(thread.related[0].key, msgD.key)
+            t.equal(thread.related[1].key, msgC.key)
+            t.equal(thread.related[2].key, msgB.key)
+
+            var msgs = threadlib.flattenThread(thread)
+            t.equal(msgs.length, 4)
+            // ensure msgs were reordered correctly
+            t.equal(msgs[0].key, msgA.key)
+            t.equal(msgs[1].key, msgB.key) 
+            t.equal(msgs[2].key, msgC.key)
+            t.equal(msgs[3].key, msgD.key)
+            t.end()
+          })
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
Adds `flattenThread` to build the thread into a flat, and correctly ordered, list, which is good for rendering in patchwork. This means:
1. putting all renderable messages (root, replies, and mentions) in a flat msgs list (so no recursion is required to render)
2. ordering the list such that replies are always after their immediate parent
3. weaving in mentions in a second pass (if a mention is also a reply, we want that to take priority, so we do it on a second pass)
4. detecting missing parents and weaving in notfound objects
