### PR TITLE
Tracking PR: Revision getters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -57,7 +57,4 @@ threadlib.getRevisions(ssb, thread, callback)
 
 // get the latest revision of an existing message
 threadlib.getLatestRevision(ssb, msg, callback)
-
-// produces the previous revisions of a msg going back to the original msg
-threadlib.createRevisionLog(ssb, msg, cb)
 ```

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ threadlib.getParentPostThread (ssb, mid, opts, cb)
 // get a flattened msg-list of the thread, ready for rendering
 threadlib.flattenThread (thread)
 
+// replace each msg in a flattened thread with its latest revision
+threadlib.reviseFlatThread(ssb, thread, cb)
+
 // get top-level thread structure (no replies of replies)
 // `opts` used in fetchThreadData
 threadlib.getPostSummary (ssb, mid, opts, cb)
@@ -48,4 +51,10 @@ threadlib.decryptThread (ssb, thread, cb)
 
 // get the last type:post msg in the thread
 threadlib.getLastThreadPost (thread)
+
+// get messages that were published as revision to an existing message
+threadlib.getRevisions(ssb, thread, callback)
+
+// get the latest revision of an existing message
+threadlib.getLatestRevision(ssb, msg, callback)
 ```

--- a/README.md
+++ b/README.md
@@ -57,4 +57,7 @@ threadlib.getRevisions(ssb, thread, callback)
 
 // get the latest revision of an existing message
 threadlib.getLatestRevision(ssb, msg, callback)
+
+// produces the previous revisions of a msg going back to the original msg
+threadlib.createRevisionLog(ssb, msg, cb)
 ```

--- a/index.js
+++ b/index.js
@@ -446,14 +446,18 @@ exports.getLatestRevision = function(ssb, msg, callback) {
   // get the revisions, and then callback on which one is latest
   exports.getRevisions(ssb, msg, function(err, msgRevisions) {
     if (err) callback(err)
-    if (msgRevisions === undefined) callback(null, msg)
-    var sortedRevisions = msgRevisions.sort(function(msg, otherMsg) {
-      // sort descending in time
-      return msg.value.timestamp < otherMsg
-    })
-    if (sortedRevisions.length === 0) { // no revisions case
-      callback(null, msg)
-    } else callback(null, sortedRevisions[0])
+    else if (msgRevisions === undefined) callback(null, msg)
+    else {
+      var sortedRevisions = msgRevisions.sort(function(msg, otherMsg) {
+        // sort descending in time
+        return msg.value.timestamp < otherMsg
+      })
+      if (sortedRevisions.length === 0) { // no revisions case
+        callback(null, msg)
+      } else {
+        callback(null, sortedRevisions[0])
+      }
+    }
   })
 }
 

--- a/index.js
+++ b/index.js
@@ -2,11 +2,6 @@ var mlib = require('ssb-msgs')
 var pull = require('pull-stream')
 var multicb = require('multicb')
 
-// shim for array.includes from es6
-Array.prototype.includes = function(item) {
-  return this.indexOf(item) !== -1
-}
-
 exports.fetchThreadRootID = function (ssb, mid, cb) {
   mid = (mid && typeof mid == 'object') ? mid.key : mid
   up()
@@ -137,7 +132,7 @@ exports.flattenThread = function (thread) {
     addedIds.add(msg.key)
   }
   function flattenAndReorderReplies (msg) {
-    if (thingsThatArePosts.includes(msg.value.content.type) &&
+    if (includes(thingsThatArePosts, msg.value.content.type) &&
         isaReplyTo(msg, thread)) {
       insertReply(msg)
       ;(msg.related||[]).forEach(flattenAndReorderReplies)
@@ -159,7 +154,7 @@ exports.flattenThread = function (thread) {
        if (addedIds.has(msg.key))
          return // skip duplicates
        // insert if a mention to its parent
-       if (thingsThatArePosts.includes(msg.value.content.type) &&
+       if (includes(thingsThatArePosts, msg.value.content.type) &&
            isaMentionTo(msg, parent))
          insertMention(msg, parent.key)
      })
@@ -491,4 +486,8 @@ function removeThreadDuplicates(threadArr) {
     uniqFlatThread.push(threadArr.find(function(t) { return uniqKeys[item] === t.key }))
   }
   return uniqFlatThread
+}
+
+function includes(array, item) {
+  return array.indexOf(item > -1)
 }

--- a/index.js
+++ b/index.js
@@ -468,7 +468,7 @@ exports.getLatestRevision = function(ssb, msg, callback) {
     else {
       var sortedRevisions = msgRevisions.sort(function(msg, otherMsg) {
         // sort descending in time
-        return msg.value.timestamp < otherMsg
+        return msg.value.timestamp > otherMsg
       })
       if (sortedRevisions.length === 0) { // no revisions case
         callback(null, msg)

--- a/index.js
+++ b/index.js
@@ -551,3 +551,19 @@ function isaReplyTo (a, b) {
 function isaMentionTo (a, b) {
   return mlib.relationsTo(a, b).indexOf('mentions') >= 0
 }
+
+function isaRevisionTo (a, b) {
+  var rels = mlib.relationsTo(a, b)
+  return rels.indexOf('revision') >= 0
+}
+
+function removeThreadDuplicates(threadArr) {
+  // remove duplicates by converting keys into a set
+  const uniqKeys = new Set(results.map((t) => t.key))
+  var uniqFlatThread = []
+  
+  for (var item of uniqKeys) {
+    uniqFlatThread.push(results.find((t) => t.key === item))
+  }
+  return uniqFlatThread
+}

--- a/index.js
+++ b/index.js
@@ -65,9 +65,12 @@ exports.reviseFlatThread = function(ssb, thread, callback) {
 
   thread.forEach(function (thisMsg) { 
     // we don't *need* to get the latest revision of an edit, it's included
-    // already
+    // already...
     if (thisMsg.value.content.type === 'post') {
       exports.getLatestRevision(ssb, thisMsg, callbackAggregator())
+    } else if (thisMsg.value.content.type !== 'post-edit') {
+      // ...so we ignore post-edits and let everything else pass through
+      passthru(thisMsg, callbackAggregator)
     }
   })
   
@@ -490,4 +493,9 @@ function removeThreadDuplicates(threadArr) {
 
 function includes(array, item) {
   return array.indexOf(item > -1)
+}
+
+function passthru(output, callback) {
+  // passes output without error to callback
+  callback(null, output)
 }

--- a/index.js
+++ b/index.js
@@ -436,16 +436,16 @@ exports.getRevisions = function(ssb, thread, callback) {
   }
             
 
-  if (!thread.related) { // if the thread doesn't have its related objects,
+  if (!thread.hasOwnProperty('related')) { // if the thread doesn't have its related objects,
                          // fetch them
     ssb.relatedMessages(thread, function(err, enrichedThread) {
       if (err) throw err
-      else if (!enrichedThread.related) callback([]) // if still no related objects
+      else if (!enrichedThread.hasOwnProperty('related')) callback([]) // if still no related objects
       else callback(collectRevisions(enrichedThread))
     })
   } else { // note: this branch is technically synchronous and the above is not
            // :(
-    callback(collectRevisions(enrichedThread))
+    callback(collectRevisions(thread))
   }  
 }
 

--- a/index.js
+++ b/index.js
@@ -469,6 +469,10 @@ exports.getLatestRevision = function (ssb, thread, callback) {
       else if (!richMsg.hasOwnProperty('related')) { callback(null, richMsg) }
       else { traverseRelatedEdits(richMsg, callback) }
     })
+  } else if (!msg.hasOwnProperty('related')) {
+    callback(null, msg)
+  } else {
+    traverseRelatedEdits(msg, callback)
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -54,7 +54,11 @@ exports.getPostThread = function (ssb, mid, opts, cb) {
   // get message and full tree of backlinks
   ssb.relatedMessages({ id: mid, count: true }, function (err, thread) {
     if (err) return cb(err)
-    exports.fetchThreadData(ssb, thread, opts, cb)
+
+    // get latest revision
+    exports.getLatestRevision(ssb, thread, function(thread) {
+      exports.fetchThreadData(ssb, thread, opts, cb)
+    })
   })
 }
 

--- a/index.js
+++ b/index.js
@@ -460,9 +460,9 @@ exports.getLatestRevision = function(ssb, msg, callback) {
       // sort descending in time
       return msg.value.timestamp < otherMsg
     })
-    if (sortedRevisions === undefined) // no revisions case
+    if (sortedRevisions.length === 0) { // no revisions case
       callback(msg)
-    else callback(sortedRevisions[0])
+    } else callback(sortedRevisions[0])
   })
 }
 

--- a/index.js
+++ b/index.js
@@ -67,8 +67,18 @@ exports.reviseFlatThread = function(ssb, thread, callback) {
   })
 
   callbackAggregator((err, results) => {
-    if (err) {callback(err)}
-    else callback(null, results)
+    if (err) {
+      callback(err)
+    } else { 
+      // remove duplicates by converting keys into a set
+      const uniqKeys = new Set(results.map((t) => t.key))
+      var uniqFlatThread = []
+
+      for (var item of uniqKeys) {
+        uniqFlatThread.push(results.find((t) => t.key === item))
+      }
+      callback(null, uniqFlatThread) 
+    }
   })
 }
 

--- a/index.js
+++ b/index.js
@@ -398,8 +398,8 @@ exports.getRevisions = function(ssb, thread, callback) {
     // this function walks the revisions of a given thread, collecting them up
     // asyncly
 
-    return thread.related
-      .map(function(relatedMsg) {
+    var threadRevisions = thread.related
+        .map(function(relatedMsg) {
       
         if (relatedMsg.value.content.type === 'post-edit' &&
             // ^ make sure it's an edit
@@ -416,23 +416,27 @@ exports.getRevisions = function(ssb, thread, callback) {
       .sort(function (oneRev, otherRev) { // remove duplicates by sorting and
                                           // reducing over the sorted arr
         return oneRev.key < otherRev.key
-      })
-      .reduce(function(prevRevs, thisRev, thisInd) {
-        var previousKey = "";
-        prevRevs.length ?
-          previousKey = prevRevs[prevRevs.length - 1].key :
-          previousKey = prevRevs.key
-        if (previousKey === thisRev.key) {
-          // remove duplicate
-          return (prevRevs instanceof Array ? prevRevs : [prevRevs])
-        } else {
-          if (!prevRevs.concat) { // js, your reduce is strange
-            return [].concat(prevRevs, thisRev)
+      });
+    if (threadRevisions.length > 0) {
+      threadRevisions =
+        threadRevisions.reduce(function(prevRevs, thisRev, thisInd) {
+          var previousKey = "";
+          prevRevs.length ?
+            previousKey = prevRevs[prevRevs.length - 1].key :
+            previousKey = prevRevs.key
+          if (previousKey === thisRev.key) {
+            // remove duplicate
+            return (prevRevs instanceof Array ? prevRevs : [prevRevs])
           } else {
-            return prevRevs.concat(thisRev)
+            if (!prevRevs.concat) { // js, your reduce is strange
+              return [].concat(prevRevs, thisRev)
+            } else {
+              return prevRevs.concat(thisRev)
+            }
           }
-        }
-      })
+        })
+    }
+    return threadRevisions
   }
             
 

--- a/index.js
+++ b/index.js
@@ -545,8 +545,8 @@ function removeThreadDuplicates(threadArr) {
   const uniqKeys = new Set(threadArr.map(function(t) { return t.key}))
   var uniqFlatThread = []
   
-  for (var item of uniqKeys) {
-    uniqFlatThread.push(threadArr.find(function(t) { return t.key === item}))
+  for (var item in uniqKeys) {
+    uniqFlatThread.push(threadArr.find(function(t) { return t.key === uniqKeys[item]}))
   }
   return uniqFlatThread
 }

--- a/index.js
+++ b/index.js
@@ -440,7 +440,7 @@ exports.getRevisions = function(ssb, thread, callback) {
 
   if (!thread.hasOwnProperty('related')) { // if the thread doesn't have its related objects,
                          // fetch them
-    ssb.relatedMessages(thread, function(err, enrichedThread) {
+    ssb.relatedMessages({id: thread.key, count: true}, function(err, enrichedThread) {
       if (err) callback (err)
       // if still no related objects
       else if (!enrichedThread.hasOwnProperty('related')) callback(null, [])

--- a/index.js
+++ b/index.js
@@ -386,6 +386,13 @@ exports.getLastThreadPost = function (thread) {
   return msg
 }
 
+exports.getLatestRevision = function(msg) {
+  // get the revisions, and then return which one is latest
+  return getRevisions(msg).sort(function(msg, otherMsg) {
+    return msg.value.timestamp < otherMsg;
+  })[0];
+}
+
 function isaReplyTo (a, b) {
   var rels = mlib.relationsTo(a, b)
   return rels.indexOf('root') >= 0 || rels.indexOf('branch') >= 0

--- a/index.js
+++ b/index.js
@@ -446,7 +446,7 @@ exports.getLatestRevision = function(ssb, msg, callback) {
   // get the revisions, and then callback on which one is latest
   exports.getRevisions(ssb, msg, function(err, msgRevisions) {
     if (err) callback(err)
-    if (msgRevisions === undefined) callback(null, [])
+    if (msgRevisions === undefined) callback(null, msg)
     var sortedRevisions = msgRevisions.sort(function(msg, otherMsg) {
       // sort descending in time
       return msg.value.timestamp < otherMsg

--- a/index.js
+++ b/index.js
@@ -460,7 +460,9 @@ exports.getLatestRevision = function(ssb, msg, callback) {
       // sort descending in time
       return msg.value.timestamp < otherMsg
     })
-    callback(sortedRevisions[0])
+    if (sortedRevisions === undefined) // no revisions case
+      callback(msg)
+    else callback(sortedRevisions[0])
   })
 }
 

--- a/index.js
+++ b/index.js
@@ -478,7 +478,7 @@ exports.getLatestRevision = function(ssb, msg, callback) {
     else {
       var sortedRevisions = msgRevisions.sort(function(msg, otherMsg) {
         // sort descending in time
-        return msg.value.timestamp > otherMsg
+        return msg.value.timestamp < otherMsg.value.timestamp
       })
       if (sortedRevisions.length === 0) { // no revisions case
         callback(null, msg)

--- a/index.js
+++ b/index.js
@@ -79,6 +79,7 @@ exports.flattenThread = function (thread) {
   // 2. ordering the list such that replies are always after their immediate parent
   // 3. weaving in mentions in a second pass (if a mention is also a reply, we want that to take priority)
   // 4. detecting missing parents and weaving in "hey this is missing" objects
+  const thingsThatArePosts = ['post', 'post-edit'] // things we think are posts
   var related = (thread.related||[])
   var availableIds = new Set([thread.key].concat(related.map(function (m) { return m.key })))
   var addedIds = new Set([thread.key])
@@ -123,7 +124,8 @@ exports.flattenThread = function (thread) {
     addedIds.add(msg.key)
   }
   function flattenAndReorderReplies (msg) {
-    if (msg.value.content.type == 'post' && isaReplyTo(msg, thread)) {
+    if (thingsThatArePosts.indexOf(msg.value.content.type !== -1) && 
+        isaReplyTo(msg, thread)) {
       insertReply(msg)
       ;(msg.related||[]).forEach(flattenAndReorderReplies)
     }
@@ -144,7 +146,7 @@ exports.flattenThread = function (thread) {
       if (addedIds.has(msg.key))
         return // skip duplicates
       // insert if a mention to its parent
-      if (msg.value.content.type == 'post' && isaMentionTo(msg, parent))
+      if (thingsThatArePosts.indexOf(msg.value.content.type !== -1) && isaMentionTo(msg, parent))
         insertMention(msg, parent.key)
     })
   }

--- a/index.js
+++ b/index.js
@@ -62,8 +62,8 @@ exports.reviseFlatThread = function(ssb, thread, callback) {
   // function that calls getLatestRevision on each of the elements of a flat
   // thread, and collects them up into one callback.
   var callbackAggregator = multicb({pluck: 1})
-  
-  thread.forEach((thisMsg) => { 
+
+  thread.forEach(function (thisMsg) { 
     // we don't *need* to get the latest revision of an edit, it's included
     // already
     if (thisMsg.value.content.type === 'post') {
@@ -74,7 +74,7 @@ exports.reviseFlatThread = function(ssb, thread, callback) {
   callbackAggregator(function (err, results) {
     if (err) {
       callback(err)
-    } else { 
+    } else {
       callback(null, results)
     }
   })
@@ -420,13 +420,11 @@ exports.getRevisions = function(ssb, thread, callback) {
     var deepThread = pluckRecursively(thread, 'related')[0]
 
     var threadRevisionLogCB = multicb({pluck: 1})
-    var threadRevisions = deepThread
-      .filter((relatedMsg) => {
-        return isaRevisionTo(relatedMsg, thread)
-      })
-      .map(function(edit) {
-        exports.createRevisionLog(ssb, edit, threadRevisionLogCB())
-      })
+    deepThread
+    .filter((relatedMsg) => isaRevisionTo(relatedMsg, thread))
+    .forEach(function(edit) {
+      exports.createRevisionLog(ssb, edit, threadRevisionLogCB())
+    })
     
     threadRevisionLogCB(function(err, revLogs) {
       if (err) callback(err)

--- a/index.js
+++ b/index.js
@@ -56,9 +56,10 @@ exports.getPostThread = function (ssb, mid, opts, cb) {
     if (err) return cb(err)
 
     // get latest revision
-    // exports.getLatestRevision(ssb, thread, function(thread) {
+    exports.getLatestRevision(ssb, thread, function(err, thread) {
+      if (err) return cb(err)
       exports.fetchThreadData(ssb, thread, opts, cb)
-    // })
+    })
   })
 }
 

--- a/index.js
+++ b/index.js
@@ -412,14 +412,24 @@ exports.getLastThreadPost = function (thread) {
   return msg
 }
 
+
 /* post revision utils */
 
 exports.getRevisions = function(ssb, thread, callback) {
   function collectRevisions(thread) {
     // this function walks the revisions of a given thread, collecting them up
     // asyncly
+    function pluckRecursively( a, prop, mem ){
+      mem = mem || [];
+      if( a[prop] ){
+        mem.push(a[prop]);
+        pluckRecursively( a[prop], prop, mem );
+      }
+      return mem;
+    }
+    var deepThread = pluckRecursively(thread, 'related')[0]
     try {
-      var threadRevisions = thread.related
+      var threadRevisions = deepThread
         .filter((relatedMsg) => {
           const relMsg = (relatedMsg.value.content)
           const isPost = (relMsg.type === 'post-edit')
@@ -446,8 +456,8 @@ exports.getRevisions = function(ssb, thread, callback) {
   }
             
 
-  if (!thread.hasOwnProperty('related')) { // if the thread doesn't have its related objects,
-                         // fetch them
+  if (!thread.hasOwnProperty('related')) { 
+  // if the thread doesn't have its related objects,fetch them
     ssb.relatedMessages({id: thread.key, count: true}, function(err, enrichedThread) {
       if (err) callback (err)
       // if still no related objects

--- a/index.js
+++ b/index.js
@@ -53,12 +53,13 @@ exports.getPostThread = function (ssb, mid, opts, cb) {
 
   // get message and full tree of backlinks
   ssb.relatedMessages({ id: mid, count: true }, function (err, thread) {
+    console.log(thread)
     if (err) return cb(err)
 
     // get latest revision
-    exports.getLatestRevision(ssb, thread, function(thread) {
+    // exports.getLatestRevision(ssb, thread, function(thread) {
       exports.fetchThreadData(ssb, thread, opts, cb)
-    })
+    // })
   })
 }
 

--- a/index.js
+++ b/index.js
@@ -421,7 +421,7 @@ exports.getRevisions = function(ssb, thread, callback) {
 
     var threadRevisionLogCB = multicb({pluck: 1})
     deepThread
-    .filter((relatedMsg) => isaRevisionTo(relatedMsg, thread))
+    .filter(function(relatedMsg) { return isaRevisionTo(relatedMsg, thread) })
     .forEach(function(edit) {
       exports.createRevisionLog(ssb, edit, threadRevisionLogCB())
     })
@@ -438,9 +438,10 @@ exports.getRevisions = function(ssb, thread, callback) {
         })
 
       // the longest such log is the one that contains all of the revisions
-      const logLengths = connectedLogs.map((log) => log.length)
-      const thisLog = connectedLogs.find((log) => 
-        log.length === Math.max.apply(Math, logLengths))
+      const logLengths = connectedLogs.map(function(log) { return log.length })
+      const thisLog = connectedLogs.find(function(log) {
+                        return log.length === Math.max.apply(Math, logLengths)
+                      })
       callback(null, thisLog)
     })
     
@@ -541,11 +542,11 @@ function isaRevisionTo (a, b) {
 
 function removeThreadDuplicates(threadArr) {
   // remove duplicates by converting keys into a set
-  const uniqKeys = new Set(threadArr.map((t) => t.key))
+  const uniqKeys = new Set(threadArr.map(function(t) { return t.key}))
   var uniqFlatThread = []
   
   for (var item of uniqKeys) {
-    uniqFlatThread.push(threadArr.find((t) => t.key === item))
+    uniqFlatThread.push(threadArr.find(function(t) { return t.key === item}))
   }
   return uniqFlatThread
 }

--- a/index.js
+++ b/index.js
@@ -445,6 +445,8 @@ exports.getRevisions = function(ssb, thread, callback) {
 exports.getLatestRevision = function(ssb, msg, callback) {
   // get the revisions, and then callback on which one is latest
   exports.getRevisions(ssb, msg, function(err, msgRevisions) {
+    if (err) callback(err)
+    if (msgRevisions === undefined) callback(null, [])
     var sortedRevisions = msgRevisions.sort(function(msg, otherMsg) {
       // sort descending in time
       return msg.value.timestamp < otherMsg

--- a/index.js
+++ b/index.js
@@ -431,14 +431,16 @@ exports.getRevisions = function(ssb, thread, callback) {
     try {
       var threadRevisions = deepThread
         .filter((relatedMsg) => {
-          const relMsg = (relatedMsg.value.content)
-          const isPost = (relMsg.type === 'post-edit')
-          const sameAuthor = (relatedMsg.value.author 
-                                === thread.value.author)
-          const revisesRoot = (relMsg.root === thread.key &&
-                               relMsg.revision === thread.key)
+          const relMsg       = (relatedMsg.value.content)
+          const isPost       = (relMsg.type === 'post-edit')
+          const sameAuthor   = 
+                  (relatedMsg.value.author === thread.value.author)
+          const isWiki       = (relatedMsg.value.author === 'wiki')
+          const revisesRoot  = (relMsg.root === thread.key)
           const revisesReply = (relMsg.revision === thread.key)
-          return isPost && sameAuthor && (revisesRoot || revisesReply)
+          return isPost && 
+              (sameAuthor || isWiki) && 
+              (revisesRoot || revisesReply)
         })
 
       // remove duplicates by converting keys into a set

--- a/test/revisions.js
+++ b/test/revisions.js
@@ -1,0 +1,93 @@
+var tape      = require('tape')
+var multicb   = require('multicb')
+var level     = require('level-test')()
+var sublevel  = require('level-sublevel/bytewise')
+var SSB       = require('secure-scuttlebutt')
+var defaults  = require('secure-scuttlebutt/defaults')
+var ssbKeys   = require('ssb-keys')
+var threadlib = require('../')
+var mlib = require('ssb-msgs')
+var schemas   = require('ssb-msg-schemas')
+
+var db = sublevel(level('test-patchwork-threads-flatten-noreplies', {
+  valueEncoding: defaults.codec
+}))
+var ssb = SSB(db, defaults)
+
+tape('getRevisions returns an array', function(t) {
+  t.plan(1)
+  
+  var alice = ssb.createFeed(ssbKeys.generate())
+
+  alice.add({ type: 'post', text: 'a' }, function (err, origMsg) {
+    if (err) throw err
+
+    threadlib.getRevisions(ssb, origMsg, function(revisions) {
+      t.ok(revisions instanceof Array)
+    })
+
+  })
+})
+
+tape('getRevisions returns an array with the right number and type of revisions',
+     function(t) {
+     t.plan(2)
+     
+       var alice = ssb.createFeed(ssbKeys.generate())
+
+       alice.add({ type: 'post', text: 'a' }, function (err, origMsg) {
+         if (err) throw err
+         
+         // add revision  
+         alice.add(schemas.postEdit('foo', origMsg.key, null, origMsg.key), function(err, revisionA) {
+           if (err) throw err
+           var msg = origMsg;
+           
+           threadlib.getRevisions(ssb, msg, function(revisions){
+             t.equal(revisions.length, 1)
+             t.ok(revisions.every(function(rev){
+               return rev.value.content.type === 'post-edit'               
+             }))
+             t.end()
+           })
+         })
+       })
+     })
+ 
+tape('getLatestRevision returns the latest rev of a msg', function(t) {
+  t.plan(2)
+  
+  var alice = ssb.createFeed(ssbKeys.generate())
+  
+  alice.add({ type: 'post', text: 'a' }, function (err, origMsg) {
+    if (err) throw err
+    
+    // add revision  
+    alice.add(schemas.postEdit('foo', origMsg.key, null, origMsg.key), function(err, revisionA) {
+      if (err) throw err
+      var msg = origMsg;
+
+      threadlib.getLatestRevision(ssb, msg, function(latestRev) {
+        t.equal(latestRev.value.content.type, 'post-edit')
+        t.ok(latestRev.value.timestamp > msg.value.timestamp)
+        t.end()
+      })
+      
+    })
+  })  
+})
+ 
+tape('getLatestRevision returns an empty array if no revisions', function(t) {
+  t.plan(1)
+  
+  var alice = ssb.createFeed(ssbKeys.generate())
+  
+  alice.add({ type: 'post', text: 'a' }, function (err, origMsg) {
+    if (err) throw err
+
+    threadlib.getLatestRevision(ssb, origMsg, function(latestRev) {
+      t.notOk(latestRev)
+      t.end()
+    })
+  })
+})

--- a/test/revisions.js
+++ b/test/revisions.js
@@ -67,37 +67,36 @@ tape('getRevisions returns an array', function(t) {
 tape('getRevisions returns an array with the right number and type of revisions',
      function(t) {
      t.plan(3)
-
-     var db = sublevel(level('test-patchwork-threads-revision-array-count', {
-       valueEncoding: defaults.codec
-     }))
-     var ssb = SSB(db, defaults)
-
-     
+       
+       var db = sublevel(level('test-patchwork-threads-revision-array-count', {
+         valueEncoding: defaults.codec
+       }))
+       var ssb = SSB(db, defaults)
        var alice = ssb.createFeed(ssbKeys.generate())
-
+       
        alice.add({ type: 'post', text: 'a' }, function (err, origMsg) {
          if (err) throw err
          
          // add revision  
          alice.add(schemas.postEdit('foo', origMsg.key, null, origMsg.key), 
-           function(err, revisionA) {
-             if (err) throw err
-             var msg = origMsg;
-
-             threadlib.getRevisions(ssb, msg, function(err, revisions) {
-               if (err) throw err
-               t.equal(revisions.length, 2)
-               t.equal(revisions[revisions.length-1].value.content.type, 'post')
-               t.ok(revisions.slice(0,1).every(function(rev){
-                 return rev.value.content.type === 'post-edit'
-               }))
-               t.end()
-             })
-           })
+                   function(err, revisionA) {
+                     if (err) throw err
+                     var msg = origMsg;
+                     
+                     threadlib.getRevisions(ssb, msg, function(err, revisions) {
+                       if (err) throw err
+                       
+                       t.equal(revisions.length, 2)
+                       t.equal(revisions[revisions.length-1].value.content.type, 'post')
+                       t.ok(revisions.slice(0,1).every(function(rev){
+                         return rev.value.content.type === 'post-edit'
+                       }))
+                       t.end()
+                     })
+                   })
        })
      })
- 
+
 tape('getLatestRevision returns the latest rev of a msg', function(t) {
   t.plan(2)
   

--- a/test/revisions.js
+++ b/test/revisions.js
@@ -441,13 +441,13 @@ tape('reviseFlatThread returns only one revision of each message in order',
                                               threadlib.getLatestRevision(ssb, msgA, revisionsCallback())
                                               threadlib.getLatestRevision(ssb, msgB, revisionsCallback())
                                               threadlib.getLatestRevision(ssb, msgC, revisionsCallback())
-                                                debugger
-                                                revisionsCallback(function(err, latestRevs) {
-                                                  t.equal(newFlatThread.length, 4)
-                                                  t.equal(newFlatThread[0].value.content.text, 'a-revised2')
-                                                  t.equal(newFlatThread[1].value.content.text, 'b')
-                                                  t.equal(newFlatThread[2].value.content.text, 'c-revised')
-                                                  t.end()
+
+                                              revisionsCallback(function(err, latestRevs) {
+                                                t.equal(newFlatThread.length, 3)
+                                                t.equal(newFlatThread[0].value.content.text, 'a-revised2')
+                                                t.equal(newFlatThread[1].value.content.text, 'b')
+                                                t.equal(newFlatThread[2].value.content.text, 'c-revised')
+                                                t.end()
                                   })
                                 })
                               })                                            

--- a/test/revisions.js
+++ b/test/revisions.js
@@ -149,9 +149,9 @@ tape('reviseFlatThread returns the latest revision of every member of a thread',
     // load test thread into ssb
     alice.add({ type: 'post', text: 'a' }, function (err, msgA) {
       if (err) throw err
-       alice.add(schemas.postEdit('foo', msgA.key, null, msgA.key), 
+       alice.add({type: 'post-edit', text: 'a-revised', 
+                  root: msgA.key, revision: msgA.key},
          function(err, revisionA) {
-      
           // first reply
           bob.add({ type: 'post', text: 'b', root: msgA.key }, function (err, msgB) {
             if (err) throw err
@@ -161,7 +161,8 @@ tape('reviseFlatThread returns the latest revision of every member of a thread',
               function (err, msgC) {
                 if (err) throw err
           
-                carla.add(schemas.postEdit('foo', msgC.key, null, msgC.key), 
+                carla.add({type: 'post-edit', text: 'c-revised', 
+                           root: msgA.key, revision: msgC.key},
                   function(err, revisionC) {
 
                     // fetch and flatten the complete unedited thread

--- a/test/revisions.js
+++ b/test/revisions.js
@@ -9,14 +9,14 @@ var threadlib = require('../')
 var mlib = require('ssb-msgs')
 var schemas   = require('ssb-msg-schemas')
 
-var db = sublevel(level('test-patchwork-threads-flatten-noreplies', {
-  valueEncoding: defaults.codec
-}))
-var ssb = SSB(db, defaults)
-
 tape('getRevisions returns an array', function(t) {
   t.plan(1)
-  
+  var db = sublevel(level('test-patchwork-threads-revision-array', {
+    valueEncoding: defaults.codec
+  }))
+  var ssb = SSB(db, defaults)
+
+
   var alice = ssb.createFeed(ssbKeys.generate())
 
   alice.add({ type: 'post', text: 'a' }, function (err, origMsg) {
@@ -32,6 +32,12 @@ tape('getRevisions returns an array', function(t) {
 tape('getRevisions returns an array with the right number and type of revisions',
      function(t) {
      t.plan(2)
+
+     var db = sublevel(level('test-patchwork-threads-revision-array-count', {
+       valueEncoding: defaults.codec
+     }))
+     var ssb = SSB(db, defaults)
+
      
        var alice = ssb.createFeed(ssbKeys.generate())
 
@@ -57,6 +63,10 @@ tape('getRevisions returns an array with the right number and type of revisions'
 tape('getLatestRevision returns the latest rev of a msg', function(t) {
   t.plan(2)
   
+  var db = sublevel(level('test-patchwork-threads-latest-rev', {
+    valueEncoding: defaults.codec
+  }))
+  var ssb = SSB(db, defaults)
   var alice = ssb.createFeed(ssbKeys.generate())
   
   alice.add({ type: 'post', text: 'a' }, function (err, origMsg) {
@@ -79,7 +89,10 @@ tape('getLatestRevision returns the latest rev of a msg', function(t) {
  
 tape('getLatestRevision returns the original msg if no revisions', function(t) {
   t.plan(1)
-  
+  var db = sublevel(level('test-patchwork-threads-no-rev', {
+    valueEncoding: defaults.codec
+  }))
+  var ssb = SSB(db, defaults)
   var alice = ssb.createFeed(ssbKeys.generate())
   
   alice.add({ type: 'post', text: 'a' }, function (err, origMsg) {
@@ -91,3 +104,92 @@ tape('getLatestRevision returns the original msg if no revisions', function(t) {
     })
   })
 })
+
+tape('reviseFlatThread returns the original message if only one is present', 
+  function(t) {
+    t.plan(2)
+
+    var db = sublevel(level('test-patchwork-threads-revise-single-msg', {
+      valueEncoding: defaults.codec
+    }))
+    var ssb = SSB(db, defaults)
+
+    var alice = ssb.createFeed(ssbKeys.generate())
+  
+    alice.add({ type: 'post', text: 'a' }, function (err, msgA) {
+      if (err) throw err
+      threadlib.getPostThread(ssb, msgA.key, {}, function (err, thread) {
+        if (err) throw err
+                      
+        var flatThread = threadlib.flattenThread(thread)
+        threadlib.reviseFlatThread(ssb, flatThread, 
+          function(err, newFlatThread) {
+            t.equal(newFlatThread.length, 1)
+            t.equal(newFlatThread[0].key, msgA.key)
+            t.end()
+          })
+        })
+    })
+  })
+
+tape('reviseFlatThread returns the latest revision of every member of a thread', 
+  function(t) {
+    t.plan(4)
+    
+    var db = sublevel(level('test-patchwork-threads-revise-every-msg', {
+      valueEncoding: defaults.codec
+    }))
+    var ssb = SSB(db, defaults)
+
+    var alice = ssb.createFeed(ssbKeys.generate())
+    var bob = ssb.createFeed(ssbKeys.generate())
+    var carla = ssb.createFeed(ssbKeys.generate())
+  
+    // begin callback hellpyramid
+    // load test thread into ssb
+    alice.add({ type: 'post', text: 'a' }, function (err, msgA) {
+      if (err) throw err
+       alice.add(schemas.postEdit('foo', msgA.key, null, msgA.key), 
+         function(err, revisionA) {
+      
+          // first reply
+          bob.add({ type: 'post', text: 'b', root: msgA.key }, function (err, msgB) {
+            if (err) throw err
+
+            // second reply
+            carla.add({ type: 'post', text: 'c', root: msgA.key, branch: msgB.key }, 
+              function (err, msgC) {
+                if (err) throw err
+          
+                carla.add(schemas.postEdit('foo', msgC.key, null, msgC.key), 
+                  function(err, revisionC) {
+
+                    // fetch and flatten the complete unedited thread
+                    threadlib.getPostThread(ssb, msgA.key, {}, function (err, thread) {
+                      if (err) throw err
+                      
+                      var flatThread = threadlib.flattenThread(thread)
+                      
+                      // get each of the revisions manually
+                      var revisionsCallback = multicb({pluck: 1})
+                      threadlib.getLatestRevision(ssb, msgA, revisionsCallback())
+                      threadlib.getLatestRevision(ssb, msgB, revisionsCallback())
+                      threadlib.getLatestRevision(ssb, msgC, revisionsCallback())
+              
+                      threadlib.reviseFlatThread(ssb, flatThread, 
+                        function(err, newFlatThread) {
+                          revisionsCallback(function(err, latestRevs) {
+                            t.equal(newFlatThread.length, 3)
+                            t.equal(newFlatThread[0].key, latestRevs[0].key)
+                            t.equal(newFlatThread[1].key, latestRevs[1].key)
+                            t.equal(newFlatThread[2].key, latestRevs[2].key)
+                            t.end()
+                          })
+                        })                                            
+                      })
+                  })
+              })
+          })
+        })
+    })
+ })

--- a/test/revisions.js
+++ b/test/revisions.js
@@ -77,16 +77,16 @@ tape('getLatestRevision returns the latest rev of a msg', function(t) {
   })  
 })
  
-tape('getLatestRevision returns an empty array if no revisions', function(t) {
+tape('getLatestRevision returns the original msg if no revisions', function(t) {
   t.plan(1)
   
   var alice = ssb.createFeed(ssbKeys.generate())
   
   alice.add({ type: 'post', text: 'a' }, function (err, origMsg) {
     if (err) throw err
-
+    
     threadlib.getLatestRevision(ssb, origMsg, function(latestRev) {
-      t.notOk(latestRev)
+      t.equal(latestRev, origMsg)
       t.end()
     })
   })

--- a/test/revisions.js
+++ b/test/revisions.js
@@ -48,11 +48,11 @@ tape('getRevisions returns an array with the right number and type of revisions'
          alice.add(schemas.postEdit('foo', origMsg.key, null, origMsg.key), function(err, revisionA) {
            if (err) throw err
            var msg = origMsg;
-           
-           threadlib.getRevisions(ssb, msg, function(err, revisions){
+
+           threadlib.getRevisions(ssb, msg, function(err, revisions) {
              t.equal(revisions.length, 1)
              t.ok(revisions.every(function(rev){
-               return rev.value.content.type === 'post-edit'               
+               return rev.value.content.type === 'post-edit'
              }))
              t.end()
            })
@@ -149,9 +149,9 @@ tape('reviseFlatThread returns the latest revision of every member of a thread',
     // load test thread into ssb
     alice.add({ type: 'post', text: 'a' }, function (err, msgA) {
       if (err) throw err
-       alice.add({type: 'post-edit', text: 'a-revised', 
-                  root: msgA.key, revision: msgA.key},
-         function(err, revisionA) {
+       // alice.add({type: 'post-edit', text: 'a-revised', 
+       //            root: msgA.key, revision: msgA.key},
+       //   function(err, revisionA) {
           // first reply
           bob.add({ type: 'post', text: 'b', root: msgA.key }, function (err, msgB) {
             if (err) throw err
@@ -172,7 +172,6 @@ tape('reviseFlatThread returns the latest revision of every member of a thread',
                         bob.add({ type: 'post-edit', text: 'b-revised', root: msgA.key, revision: msgB.key }, 
                           function (err, revisionB) {
                             if (err) throw err
-
                         
                               // fetch and flatten the complete unedited thread
                               threadlib.getPostThread(ssb, msgA.key, {}, function (err, thread) {
@@ -195,7 +194,7 @@ tape('reviseFlatThread returns the latest revision of every member of a thread',
                                     t.equal(newFlatThread[1].key, latestRevs[1].key)
                                     t.equal(newFlatThread[2].key, latestRevs[2].key)
                                     t.equal(newFlatThread[3].key, latestRevs[3].key)
-                                    t.equal(newFlatThread[0].value.content.text, 'a-revised')
+                                    t.equal(newFlatThread[0].value.content.text, 'a')
                                     t.equal(newFlatThread[1].value.content.text, 'b-revised')
                                     t.equal(newFlatThread[2].value.content.text, 'c-revised')
                                     t.equal(newFlatThread[3].value.content.text, 'b2')
@@ -207,7 +206,7 @@ tape('reviseFlatThread returns the latest revision of every member of a thread',
                       })
                   })
               })
-          })
+         // })
         })
     })
  })

--- a/test/revisions.js
+++ b/test/revisions.js
@@ -365,7 +365,7 @@ tape('reviseFlatThread returns properly even if root is revised',
                       threadlib.getLatestRevision(ssb, msgA, revisionsCallback())
                       threadlib.getLatestRevision(ssb, msgB, revisionsCallback())
                       threadlib.getLatestRevision(ssb, msgC, revisionsCallback())
-                          
+
                       threadlib.reviseFlatThread(ssb, flatThread, 
                         function(err, newFlatThread) {
                           revisionsCallback(function(err, latestRevs) {
@@ -402,26 +402,26 @@ tape('reviseFlatThread returns only one revision of each message in order',
   
     // begin callback hellpyramid
     // load test thread into ssb
-    alice.add({ type: 'post', text: 'a' }, function (err, msgA) {
+    alice.add({ type: 'post', text: 'bad-a' }, function (err, msgA) {
       if (err) throw err
 
-      alice.add({type: 'post-edit', text: 'a-revised', 
+      alice.add({type: 'post-edit', text: 'bad-a-revised', 
                  root: msgA.key, revision: msgA.key}, function(err, revisionA) {
 
         // first reply
-        bob.add({ type: 'post', text: 'b', root: msgA.key }, function (err, msgB) {
+        bob.add({ type: 'post', text: 'bad-b', root: msgA.key }, function (err, msgB) {
           if (err) throw err
 
           // second reply
-          carla.add({ type: 'post', text: 'c', root: msgA.key, branch: msgB.key }, 
+          carla.add({ type: 'post', text: 'bad-c', root: msgA.key, branch: msgB.key }, 
             function (err, msgC) {
               if (err) throw err
           
-              carla.add({type: 'post-edit', text: 'c-revised',
+              carla.add({type: 'post-edit', text: 'bad-c-revised',
                          root: msgA.key, revision: msgC.key},
                          function(err, revisionC) {
                            if (err) throw err
-                           alice.add({type: 'post-edit', text: 'a-revised2', 
+                           alice.add({type: 'post-edit', text: 'bad-a-revised2', 
                                       root: msgA.key, revision: revisionA.key},
                                       function(err, revisionA2) {
                                         if (err) throw err
@@ -435,7 +435,6 @@ tape('reviseFlatThread returns only one revision of each message in order',
                                           // get each of the revisions manually
                                           var revisionsCallback = multicb({pluck: 1})
                                           
-                                          
                                           threadlib.reviseFlatThread(ssb, flatThread, 
                                             function(err, newFlatThread) {
                                               threadlib.getLatestRevision(ssb, msgA, revisionsCallback())
@@ -444,9 +443,9 @@ tape('reviseFlatThread returns only one revision of each message in order',
 
                                               revisionsCallback(function(err, latestRevs) {
                                                 t.equal(newFlatThread.length, 3)
-                                                t.equal(newFlatThread[0].value.content.text, 'a-revised2')
-                                                t.equal(newFlatThread[1].value.content.text, 'b')
-                                                t.equal(newFlatThread[2].value.content.text, 'c-revised')
+                                                t.equal(newFlatThread[0].value.content.text, 'bad-a-revised2')
+                                                t.equal(newFlatThread[1].value.content.text, 'bad-b')
+                                                t.equal(newFlatThread[2].value.content.text, 'bad-c-revised')
                                                 t.end()
                                   })
                                 })

--- a/test/revisions.js
+++ b/test/revisions.js
@@ -300,10 +300,13 @@ tape('reviseFlatThread returns the latest revision of every member of a thread',
                                  threadlib.getLatestRevision(ssb, msgB, revisionsCallback())
                                  threadlib.getLatestRevision(ssb, msgC, revisionsCallback())
                                  threadlib.getLatestRevision(ssb, msgB2, revisionsCallback())
-                          
+
                                  threadlib.reviseFlatThread(ssb, flatThread, 
                                    function(err, newFlatThread) {
+                                     if (err) throw err
+
                                      revisionsCallback(function(err, latestRevs) {
+                                       if (err) throw err
                                        t.equal(newFlatThread.length, 4)
                                        t.equal(newFlatThread[0].key, latestRevs[0].key)
                                        t.equal(newFlatThread[1].key, latestRevs[1].key)
@@ -405,7 +408,7 @@ tape('edge 1: root edited multiple times out of sequence with rest of thread',
     var alice = ssb.createFeed(ssbKeys.generate())
     var bob = ssb.createFeed(ssbKeys.generate())
     var carla = ssb.createFeed(ssbKeys.generate())
-  
+    
     // begin callback hellpyramid
     // load test thread into ssb
     alice.add({ type: 'post', text: 'edge-a' },
@@ -415,7 +418,7 @@ tape('edge 1: root edited multiple times out of sequence with rest of thread',
                 alice.add({type: 'post-edit', text: 'edge-a-revised', 
                            root: msgA.key, revision: msgA.key},
                           function(err, revisionA) {
-                                                                  
+                            
                             // first reply
                             bob.add({ type: 'post', text: 'edge-b', root: msgA.key },
                                     function (err, msgB) {
@@ -506,9 +509,9 @@ tape('edge 2: reply edited out of sequence with rest of thread', function(t) {
 
                                                         // fetch and flatten the complete unedited thread
                                                         threadlib.getPostThread(ssb, msgA.key, {}, function (err, thread) {
-                                                                                  if (err) throw err
-                                                                                  
-                                                                                  var flatThread = threadlib.flattenThread(thread)
+                                                          if (err) throw err
+                                                          
+                                                          var flatThread = threadlib.flattenThread(thread)
                                                                                       
                                                                                   // get each of the revisions manually
                                                                                   var revisionsCallback = multicb({pluck: 1})

--- a/test/revisions.js
+++ b/test/revisions.js
@@ -100,9 +100,9 @@ tape('getRevisions returns an array with the right number and type of revisions'
            },
            function(err, revisionA) {
              if (err) throw err
+
              var msg = origMsg;
-             debugger
-             
+
              threadlib.getRevisions(ssb, msg, function(err, revisions) {
                if (err) throw err
                
@@ -638,7 +638,7 @@ tape('edge 2: reply edited out of sequence with rest of thread', function(t) {
                         
                         // get each of the revisions manually
                         var revisionsCallback = multicb({pluck: 1})
-                        debugger
+
                         threadlib.reviseFlatThread(
                           ssb, flatThread, 
                           function(err, newFlatThread) {

--- a/test/revisions.js
+++ b/test/revisions.js
@@ -149,9 +149,84 @@ tape('reviseFlatThread returns the latest revision of every member of a thread',
     // load test thread into ssb
     alice.add({ type: 'post', text: 'a' }, function (err, msgA) {
       if (err) throw err
-       // alice.add({type: 'post-edit', text: 'a-revised', 
-       //            root: msgA.key, revision: msgA.key},
-       //   function(err, revisionA) {
+      // first reply
+      bob.add({ type: 'post', text: 'b', root: msgA.key }, function (err, msgB) {
+        if (err) throw err
+
+        // second reply
+        carla.add({ type: 'post', text: 'c', root: msgA.key, branch: msgB.key }, 
+          function (err, msgC) {
+            if (err) throw err
+          
+            carla.add({type: 'post-edit', text: 'c-revised', 
+                       root: msgA.key, revision: msgC.key},
+                       function(err, revisionC) {
+
+                         // fourth reply
+                         bob.add({type: 'post', text: 'b2', root: msgA.key}, 
+                         function(err, msgB2) {
+                           // bob revises first reply
+                           bob.add({ type: 'post-edit', text: 'b-revised', root: msgA.key, revision: msgB.key }, 
+                           function (err, revisionB) {
+                             if (err) throw err
+                        
+                             // fetch and flatten the complete unedited thread
+                             threadlib.getPostThread(ssb, msgA.key, {}, function (err, thread) {
+                               if (err) throw err
+                      
+                               var flatThread = threadlib.flattenThread(thread)
+                      
+                               // get each of the revisions manually
+                               var revisionsCallback = multicb({pluck: 1})
+                               threadlib.getLatestRevision(ssb, msgA, revisionsCallback())
+                               threadlib.getLatestRevision(ssb, msgB, revisionsCallback())
+                               threadlib.getLatestRevision(ssb, msgC, revisionsCallback())
+                               threadlib.getLatestRevision(ssb, msgB2, revisionsCallback())
+                          
+                               threadlib.reviseFlatThread(ssb, flatThread, 
+                                 function(err, newFlatThread) {
+                                   revisionsCallback(function(err, latestRevs) {
+                                     t.equal(newFlatThread.length, 4)
+                                     t.equal(newFlatThread[0].key, latestRevs[0].key)
+                                     t.equal(newFlatThread[1].key, latestRevs[1].key)
+                                     t.equal(newFlatThread[2].key, latestRevs[2].key)
+                                     t.equal(newFlatThread[3].key, latestRevs[3].key)
+                                     t.equal(newFlatThread[0].value.content.text, 'a')
+                                     t.equal(newFlatThread[1].value.content.text, 'b-revised')
+                                     t.equal(newFlatThread[2].value.content.text, 'c-revised')
+                                     t.equal(newFlatThread[3].value.content.text, 'b2')
+                                     t.end()
+                                  })
+                                })
+                              })                                            
+                          })
+                      })
+                  })
+          })
+        })
+    })
+ })
+
+tape('reviseFlatThread returns properly even if root is revised', 
+  function(t) {
+    t.plan(7)
+    
+    var db = sublevel(level('test-patchwork-threads-revise-root', {
+      valueEncoding: defaults.codec
+    }))
+    var ssb = SSB(db, defaults)
+
+    var alice = ssb.createFeed(ssbKeys.generate())
+    var bob = ssb.createFeed(ssbKeys.generate())
+    var carla = ssb.createFeed(ssbKeys.generate())
+  
+    // begin callback hellpyramid
+    // load test thread into ssb
+    alice.add({ type: 'post', text: 'a' }, function (err, msgA) {
+      if (err) throw err
+       alice.add({type: 'post-edit', text: 'a-revised', 
+                  root: msgA.key, revision: msgA.key},
+         function(err, revisionA) {
           // first reply
           bob.add({ type: 'post', text: 'b', root: msgA.key }, function (err, msgB) {
             if (err) throw err
@@ -164,49 +239,35 @@ tape('reviseFlatThread returns the latest revision of every member of a thread',
                 carla.add({type: 'post-edit', text: 'c-revised', 
                            root: msgA.key, revision: msgC.key},
                   function(err, revisionC) {
+                    if (err) throw err
+                    // fetch and flatten the complete unedited thread
+                    threadlib.getPostThread(ssb, msgA.key, {}, function (err, thread) {
 
-                    // fourth reply
-                    bob.add({type: 'post', text: 'b2', root: msgA.key}, 
-                      function(err, msgB2) {
-                        // bob revises first reply
-                        bob.add({ type: 'post-edit', text: 'b-revised', root: msgA.key, revision: msgB.key }, 
-                          function (err, revisionB) {
-                            if (err) throw err
-                        
-                              // fetch and flatten the complete unedited thread
-                              threadlib.getPostThread(ssb, msgA.key, {}, function (err, thread) {
-                              if (err) throw err
+                      var flatThread = threadlib.flattenThread(thread)
                       
-                              var flatThread = threadlib.flattenThread(thread)
-                      
-                              // get each of the revisions manually
-                              var revisionsCallback = multicb({pluck: 1})
-                              threadlib.getLatestRevision(ssb, msgA, revisionsCallback())
-                              threadlib.getLatestRevision(ssb, msgB, revisionsCallback())
-                              threadlib.getLatestRevision(ssb, msgC, revisionsCallback())
-                              threadlib.getLatestRevision(ssb, msgB2, revisionsCallback())
+                      // get each of the revisions manually
+                      var revisionsCallback = multicb({pluck: 1})
+                      threadlib.getLatestRevision(ssb, msgA, revisionsCallback())
+                      threadlib.getLatestRevision(ssb, msgB, revisionsCallback())
+                      threadlib.getLatestRevision(ssb, msgC, revisionsCallback())
                           
-                              threadlib.reviseFlatThread(ssb, flatThread, 
-                                function(err, newFlatThread) {
-                                  revisionsCallback(function(err, latestRevs) {
-                                    t.equal(newFlatThread.length, 4)
-                                    t.equal(newFlatThread[0].key, latestRevs[0].key)
-                                    t.equal(newFlatThread[1].key, latestRevs[1].key)
-                                    t.equal(newFlatThread[2].key, latestRevs[2].key)
-                                    t.equal(newFlatThread[3].key, latestRevs[3].key)
-                                    t.equal(newFlatThread[0].value.content.text, 'a')
-                                    t.equal(newFlatThread[1].value.content.text, 'b-revised')
-                                    t.equal(newFlatThread[2].value.content.text, 'c-revised')
-                                    t.equal(newFlatThread[3].value.content.text, 'b2')
-                                    t.end()
-                                  })
-                                })
-                              })                                            
+                      threadlib.reviseFlatThread(ssb, flatThread, 
+                        function(err, newFlatThread) {
+                          revisionsCallback(function(err, latestRevs) {
+                            t.equal(newFlatThread.length, 3)
+                            t.equal(newFlatThread[0].key, latestRevs[0].key)
+                            t.equal(newFlatThread[1].key, latestRevs[1].key)
+                            t.equal(newFlatThread[2].key, latestRevs[2].key)
+                            t.equal(newFlatThread[0].value.content.text, 'a-revised')
+                            t.equal(newFlatThread[1].value.content.text, 'b')
+                            t.equal(newFlatThread[2].value.content.text, 'c-revised')
+                            t.end()
                           })
-                      })
+                        })
+                    })                                            
                   })
               })
-         // })
-        })
+          })
     })
- })
+  })
+})

--- a/test/revisions.js
+++ b/test/revisions.js
@@ -134,7 +134,7 @@ tape('reviseFlatThread returns the original message if only one is present',
 
 tape('reviseFlatThread returns the latest revision of every member of a thread', 
   function(t) {
-    t.plan(4)
+    t.plan(9)
     
     var db = sublevel(level('test-patchwork-threads-revise-every-msg', {
       valueEncoding: defaults.codec
@@ -165,28 +165,45 @@ tape('reviseFlatThread returns the latest revision of every member of a thread',
                            root: msgA.key, revision: msgC.key},
                   function(err, revisionC) {
 
-                    // fetch and flatten the complete unedited thread
-                    threadlib.getPostThread(ssb, msgA.key, {}, function (err, thread) {
-                      if (err) throw err
+                    // fourth reply
+                    bob.add({type: 'post', text: 'b2', root: msgA.key}, 
+                      function(err, msgB2) {
+                        // bob revises first reply
+                        bob.add({ type: 'post-edit', text: 'b-revised', root: msgA.key, revision: msgB.key }, 
+                          function (err, revisionB) {
+                            if (err) throw err
+
+                        
+                              // fetch and flatten the complete unedited thread
+                              threadlib.getPostThread(ssb, msgA.key, {}, function (err, thread) {
+                              if (err) throw err
                       
-                      var flatThread = threadlib.flattenThread(thread)
+                              var flatThread = threadlib.flattenThread(thread)
                       
-                      // get each of the revisions manually
-                      var revisionsCallback = multicb({pluck: 1})
-                      threadlib.getLatestRevision(ssb, msgA, revisionsCallback())
-                      threadlib.getLatestRevision(ssb, msgB, revisionsCallback())
-                      threadlib.getLatestRevision(ssb, msgC, revisionsCallback())
-              
-                      threadlib.reviseFlatThread(ssb, flatThread, 
-                        function(err, newFlatThread) {
-                          revisionsCallback(function(err, latestRevs) {
-                            t.equal(newFlatThread.length, 3)
-                            t.equal(newFlatThread[0].key, latestRevs[0].key)
-                            t.equal(newFlatThread[1].key, latestRevs[1].key)
-                            t.equal(newFlatThread[2].key, latestRevs[2].key)
-                            t.end()
+                              // get each of the revisions manually
+                              var revisionsCallback = multicb({pluck: 1})
+                              threadlib.getLatestRevision(ssb, msgA, revisionsCallback())
+                              threadlib.getLatestRevision(ssb, msgB, revisionsCallback())
+                              threadlib.getLatestRevision(ssb, msgC, revisionsCallback())
+                              threadlib.getLatestRevision(ssb, msgB2, revisionsCallback())
+                          
+                              threadlib.reviseFlatThread(ssb, flatThread, 
+                                function(err, newFlatThread) {
+                                  revisionsCallback(function(err, latestRevs) {
+                                    t.equal(newFlatThread.length, 4)
+                                    t.equal(newFlatThread[0].key, latestRevs[0].key)
+                                    t.equal(newFlatThread[1].key, latestRevs[1].key)
+                                    t.equal(newFlatThread[2].key, latestRevs[2].key)
+                                    t.equal(newFlatThread[3].key, latestRevs[3].key)
+                                    t.equal(newFlatThread[0].value.content.text, 'a-revised')
+                                    t.equal(newFlatThread[1].value.content.text, 'b-revised')
+                                    t.equal(newFlatThread[2].value.content.text, 'c-revised')
+                                    t.equal(newFlatThread[3].value.content.text, 'b2')
+                                    t.end()
+                                  })
+                                })
+                              })                                            
                           })
-                        })                                            
                       })
                   })
               })

--- a/test/revisions.js
+++ b/test/revisions.js
@@ -198,46 +198,47 @@ tape('reviseFlatThread returns the latest revision of every member of a thread',
                          bob.add({type: 'post', text: 'b2', root: msgA.key}, 
                          function(err, msgB2) {
                            // bob revises first reply
-                           bob.add({ type: 'post-edit', text: 'b-revised', root: msgA.key, revision: msgB.key }, 
-                           function (err, revisionB) {
-                             if (err) throw err
-                        
-                             // fetch and flatten the complete unedited thread
-                             threadlib.getPostThread(ssb, msgA.key, {}, function (err, thread) {
+                           bob.add({ type: 'post-edit', text: 'b-revised', 
+                                     root: msgA.key, revision: msgB.key }, 
+                             function (err, revisionB) {
                                if (err) throw err
+                        
+                               // fetch and flatten the complete unedited thread
+                               threadlib.getPostThread(ssb, msgA.key, {}, function (err, thread) {
+                                 if (err) throw err
                       
-                               var flatThread = threadlib.flattenThread(thread)
+                                 var flatThread = threadlib.flattenThread(thread)
                       
-                               // get each of the revisions manually
-                               var revisionsCallback = multicb({pluck: 1})
-                               threadlib.getLatestRevision(ssb, msgA, revisionsCallback())
-                               threadlib.getLatestRevision(ssb, msgB, revisionsCallback())
-                               threadlib.getLatestRevision(ssb, msgC, revisionsCallback())
-                               threadlib.getLatestRevision(ssb, msgB2, revisionsCallback())
+                                 // get each of the revisions manually
+                                 var revisionsCallback = multicb({pluck: 1})
+                                 threadlib.getLatestRevision(ssb, msgA, revisionsCallback())
+                                 threadlib.getLatestRevision(ssb, msgB, revisionsCallback())
+                                 threadlib.getLatestRevision(ssb, msgC, revisionsCallback())
+                                 threadlib.getLatestRevision(ssb, msgB2, revisionsCallback())
                           
-                               threadlib.reviseFlatThread(ssb, flatThread, 
-                                 function(err, newFlatThread) {
-                                   revisionsCallback(function(err, latestRevs) {
-                                     t.equal(newFlatThread.length, 4)
-                                     t.equal(newFlatThread[0].key, latestRevs[0].key)
-                                     t.equal(newFlatThread[1].key, latestRevs[1].key)
-                                     t.equal(newFlatThread[2].key, latestRevs[2].key)
-                                     t.equal(newFlatThread[3].key, latestRevs[3].key)
-                                     t.equal(newFlatThread[0].value.content.text, 'a')
-                                     t.equal(newFlatThread[1].value.content.text, 'b-revised')
-                                     t.equal(newFlatThread[2].value.content.text, 'c-revised')
-                                     t.equal(newFlatThread[3].value.content.text, 'b2')
-                                     t.end()
-                                  })
-                                })
-                              })                                            
-                          })
+                                 threadlib.reviseFlatThread(ssb, flatThread, 
+                                   function(err, newFlatThread) {
+                                     revisionsCallback(function(err, latestRevs) {
+                                       t.equal(newFlatThread.length, 4)
+                                       t.equal(newFlatThread[0].key, latestRevs[0].key)
+                                       t.equal(newFlatThread[1].key, latestRevs[1].key)
+                                       t.equal(newFlatThread[2].key, latestRevs[2].key)
+                                       t.equal(newFlatThread[3].key, latestRevs[3].key)
+                                       t.equal(newFlatThread[0].value.content.text, 'a')
+                                       t.equal(newFlatThread[1].value.content.text, 'b-revised')
+                                       t.equal(newFlatThread[2].value.content.text, 'c-revised')
+                                       t.equal(newFlatThread[3].value.content.text, 'b2')
+                                       t.end()
+                                     })
+                                   })
+                               })                                            
+                             })
+                         })
+                       })
                       })
-                  })
-          })
         })
-    })
- })
+      })
+  })
 
 tape('reviseFlatThread returns properly even if root is revised', 
   function(t) {
@@ -308,7 +309,7 @@ tape('reviseFlatThread returns properly even if root is revised',
 
 tape('reviseFlatThread returns only one revision of each message in order',
   function(t) {
-    t.plan(7)
+    t.plan(4)
     
     var db = sublevel(level('test-patchwork-threads-revise-multi-edit', {
       valueEncoding: defaults.codec
@@ -341,8 +342,8 @@ tape('reviseFlatThread returns only one revision of each message in order',
                          function(err, revisionC) {
                            if (err) throw err
                            alice.add({type: 'post-edit', text: 'a-revised2', 
-                                      root: msgA.key, revision: msgA.key},
-                                      function(err, revisionA) {
+                                      root: msgA.key, revision: revisionA.key},
+                                      function(err, revisionA2) {
                                         if (err) throw err
 
                                         // fetch and flatten the complete unedited thread
@@ -353,21 +354,19 @@ tape('reviseFlatThread returns only one revision of each message in order',
                                           debugger;
                                           // get each of the revisions manually
                                           var revisionsCallback = multicb({pluck: 1})
-                                          threadlib.getLatestRevision(ssb, msgA, revisionsCallback())
-                                          threadlib.getLatestRevision(ssb, msgB, revisionsCallback())
-                                          threadlib.getLatestRevision(ssb, msgC, revisionsCallback())
+                                          
                                           
                                           threadlib.reviseFlatThread(ssb, flatThread, 
                                             function(err, newFlatThread) {
-                                              revisionsCallback(function(err, latestRevs) {
-                                                t.equal(newFlatThread.length, 3)
-                                                t.equal(newFlatThread[0].key, latestRevs[0].key)
-                                                t.equal(newFlatThread[1].key, latestRevs[1].key)
-                                                t.equal(newFlatThread[2].key, latestRevs[2].key)
-                                                t.equal(newFlatThread[0].value.content.text, 'a-revised2')
-                                                t.equal(newFlatThread[1].value.content.text, 'b-revised')
-                                                t.equal(newFlatThread[2].value.content.text, 'c-revised')
-                                                t.end()
+                                              threadlib.getLatestRevision(ssb, msgA, revisionsCallback())
+                                              threadlib.getLatestRevision(ssb, msgB, revisionsCallback())
+                                              threadlib.getLatestRevision(ssb, msgC, revisionsCallback())
+                                                revisionsCallback(function(err, latestRevs) {
+                                                  t.equal(newFlatThread.length, 3)
+                                                  t.equal(newFlatThread[0].value.content.text, 'a-revised2')
+                                                  t.equal(newFlatThread[1].value.content.text, 'b')
+                                                  t.equal(newFlatThread[2].value.content.text, 'c-revised')
+                                                  t.end()
                                   })
                                 })
                               })                                            

--- a/test/revisions.js
+++ b/test/revisions.js
@@ -6,7 +6,7 @@ var SSB       = require('secure-scuttlebutt')
 var defaults  = require('secure-scuttlebutt/defaults')
 var ssbKeys   = require('ssb-keys')
 var threadlib = require('../')
-var mlib = require('ssb-msgs')
+var mlib      = require('ssb-msgs')
 var schemas   = require('ssb-msg-schemas')
 
 tape('getRevisions returns an array', function(t) {
@@ -227,6 +227,7 @@ tape('reviseFlatThread returns properly even if root is revised',
        alice.add({type: 'post-edit', text: 'a-revised', 
                   root: msgA.key, revision: msgA.key},
          function(err, revisionA) {
+      
           // first reply
           bob.add({ type: 'post', text: 'b', root: msgA.key }, function (err, msgB) {
             if (err) throw err
@@ -242,7 +243,8 @@ tape('reviseFlatThread returns properly even if root is revised',
                     if (err) throw err
                     // fetch and flatten the complete unedited thread
                     threadlib.getPostThread(ssb, msgA.key, {}, function (err, thread) {
-
+                      if (err) throw err
+                      
                       var flatThread = threadlib.flattenThread(thread)
                       
                       // get each of the revisions manually
@@ -268,6 +270,6 @@ tape('reviseFlatThread returns properly even if root is revised',
                   })
               })
           })
+        })
     })
-  })
 })

--- a/test/revisions.js
+++ b/test/revisions.js
@@ -22,7 +22,7 @@ tape('getRevisions returns an array', function(t) {
   alice.add({ type: 'post', text: 'a' }, function (err, origMsg) {
     if (err) throw err
 
-    threadlib.getRevisions(ssb, origMsg, function(revisions) {
+    threadlib.getRevisions(ssb, origMsg, function(err, revisions) {
       t.ok(revisions instanceof Array)
     })
 
@@ -43,7 +43,7 @@ tape('getRevisions returns an array with the right number and type of revisions'
            if (err) throw err
            var msg = origMsg;
            
-           threadlib.getRevisions(ssb, msg, function(revisions){
+           threadlib.getRevisions(ssb, msg, function(err, revisions){
              t.equal(revisions.length, 1)
              t.ok(revisions.every(function(rev){
                return rev.value.content.type === 'post-edit'               
@@ -67,7 +67,7 @@ tape('getLatestRevision returns the latest rev of a msg', function(t) {
       if (err) throw err
       var msg = origMsg;
 
-      threadlib.getLatestRevision(ssb, msg, function(latestRev) {
+      threadlib.getLatestRevision(ssb, msg, function(err, latestRev) {
         t.equal(latestRev.value.content.type, 'post-edit')
         t.ok(latestRev.value.timestamp > msg.value.timestamp)
         t.end()
@@ -85,7 +85,7 @@ tape('getLatestRevision returns the original msg if no revisions', function(t) {
   alice.add({ type: 'post', text: 'a' }, function (err, origMsg) {
     if (err) throw err
     
-    threadlib.getLatestRevision(ssb, origMsg, function(latestRev) {
+    threadlib.getLatestRevision(ssb, origMsg, function(err, latestRev) {
       t.equal(latestRev, origMsg)
       t.end()
     })


### PR DESCRIPTION
Starting PR a teeny bit early for discussion again.

The two functions I added (`getRevisions()` and `getLatestRevision()`) do what they say on the label and have unit tests for them, but need an ssb instance passed to them so they can fetch related messages and then filter down to revisions.

I need to get `getLatestRevision()` into `flattenThread()` so that thread rendering with post edits will "just work", but I don't want to break it by suddenly requiring it to be async. Thoughts?
