### PR TITLE
set a depth limit

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ exports.getPostThread = function (ssb, mid, opts, cb) {
   }
 
   // get message and full tree of backlinks
-  ssb.relatedMessages({ id: mid, count: true }, function (err, thread) {
+  ssb.relatedMessages({ id: mid, count: true, depth: 2 }, function (err, thread) {
     if (err) return cb(err)
     exports.fetchThreadData(ssb, thread, opts, cb)
   })

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "level-test": "^2.0.1",
     "secure-scuttlebutt": "^15.0.0",
     "ssb-keys": "^4.0.6",
+    "ssb-msg-schemas": "^6.2.1",
     "tape": "~4.0.0"
   }
 }


### PR DESCRIPTION
this change, along with my recent changes to secure-scuttlebutt, stops `relatedMessages` from going out of control. since `relatedMessages` retrives backlinked messages recursively, it meant it is possible to have infinite loops, if a message in one thread links to a another thread, and a message in that thread links back to the first thread. (in secure-scuttlebutt@15.4 `relatedMessages` filters any messages which have already been seen)

`depth=2` means that it will stop after retriving messages in the thread, plus their votes and mentions, but won't go on to get the votes or backlinks or replies to the mentioning messages.
